### PR TITLE
allow setting the -q flag with a `QUIET` ENV variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,4 +119,4 @@ chown -R ${PG_USER}:${PG_USER} ${PG_LOG}
 
 cat ${PG_CONFIG_DIR}/pgbouncer.ini
 echo "Starting pgbouncer..."
-exec pgbouncer -u ${PG_USER} ${PG_CONFIG_DIR}/pgbouncer.ini
+exec pgbouncer ${QUIET:+-q} -u ${PG_USER} ${PG_CONFIG_DIR}/pgbouncer.ini

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -117,6 +117,8 @@ mkdir -p ${PG_LOG}
 chmod -R 755 ${PG_LOG}
 chown -R ${PG_USER}:${PG_USER} ${PG_LOG}
 
-cat ${PG_CONFIG_DIR}/pgbouncer.ini
+if [ -z $QUIET ]; then
+  cat ${PG_CONFIG_DIR}/pgbouncer.ini
+fi
 echo "Starting pgbouncer..."
 exec pgbouncer ${QUIET:+-q} -u ${PG_USER} ${PG_CONFIG_DIR}/pgbouncer.ini


### PR DESCRIPTION
I have a case where it would be nice not to have all of the log-spam going to STDOUT in a docker-compose setup. This small change would allow for users to optionally turn that off.