### PR TITLE
Don't default to the postgres user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ if [ ! -f ${PG_CONFIG_DIR}/pgbouncer.ini ]; then
 # The characters “;” and “#” are not recognized when they appear later in the line.
 [databases]
 * = host=${DB_HOST:?"Setup pgbouncer config error! You must set DB_HOST env"} \
-port=${DB_PORT:-5432} user=${DB_USER:-postgres} \
+port=${DB_PORT:-5432} ${DB_USER:+user=${DB_USER}} \
 ${DB_PASSWORD:+password=${DB_PASSWORD}}
 
 [pgbouncer]


### PR DESCRIPTION
This allows more flexibility to have a host that uses the client user name and password, rather than hardcoding the username.