### PR TITLE
update and fix pgbouncer version to 1.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER brainsam@yandex.ru
 WORKDIR /
 RUN apk --update add git python py-pip build-base automake libtool m4 autoconf libevent-dev openssl-dev c-ares-dev
 RUN pip install docutils
-RUN git clone https://github.com/pgbouncer/pgbouncer.git src
+RUN git clone --branch pgbouncer_1_9_0 --depth 1 https://github.com/pgbouncer/pgbouncer.git src
 
 WORKDIR /bin
 RUN ln -s ../usr/bin/rst2man.py rst2man


### PR DESCRIPTION
Building pgbouncer against master branch is quite dangerous and messy.

`--branch` can take git tags into account
`--depth 1` create a shallow clone

We probably need to tag this repo to 1.9.0 after the merge in order to build a new docker image.

Tested locally:

```
[...]
Step 6/23 : RUN git clone --branch pgbouncer_1_9_0 --depth 1 https://github.com/pgbouncer/pgbouncer.git src
 ---> Running in aa0107421df4
Cloning into 'src'...
Note: checking out '30918baaacf702e015ee1ad2f6fc21b602bd5ec4'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

Removing intermediate container aa0107421df4
 ---> ea0bdc260268
Step 7/23 : WORKDIR /bin
 ---> Running in dae786591f97
Removing intermediate container dae786591f97
 ---> 7a2379babe57
[...]
```

```
$ docker run -e DB_HOST=localhost test-build-pgbouncer

Starting pgbouncer...
2018-10-05 09:43:25.908 1 LOG file descriptor limit: 1048576 (H:1048576), max_client_conn: 100, max fds possible: 110
2018-10-05 09:43:25.908 1 LOG listening on 0.0.0.0:6432
2018-10-05 09:43:25.909 1 LOG listening on unix:/tmp/.s.PGSQL.6432
2018-10-05 09:43:25.909 1 LOG process up: pgbouncer 1.9.0, libevent 2.1.8-stable (epoll), adns: c-ares 1.14.0, tls: OpenSSL 1.0.2p  14 Aug 2018
```