### PR TITLE
Change openssl to libressl pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest AS build_stage
 MAINTAINER brainsam@yandex.ru
 
 WORKDIR /
-RUN apk --update add git python py-pip build-base automake libtool m4 autoconf libevent-dev openssl-dev c-ares-dev
+RUN apk --update add git python py-pip build-base automake libtool m4 autoconf libevent-dev libressl-dev c-ares-dev
 RUN pip install docutils
 RUN git clone https://github.com/pgbouncer/pgbouncer.git src
 
@@ -21,7 +21,7 @@ RUN make install
 RUN ls -R /pgbouncer
 
 FROM alpine:latest
-RUN apk --update add libevent openssl c-ares
+RUN apk --update add libevent libressl c-ares
 WORKDIR /
 COPY --from=build_stage /pgbouncer /pgbouncer
 ADD entrypoint.sh ./


### PR DESCRIPTION
Newer versions of alpine require libressl rather than openssl pkg

See related CVE's:
https://nvd.nist.gov/vuln/detail/CVE-2018-0495
https://nvd.nist.gov/vuln/detail/CVE-2018-0732

Alpine patches:
https://bugs.alpinelinux.org/versions/125
https://bugs.alpinelinux.org/issues/9003
https://bugs.alpinelinux.org/issues/9008

During the `make`, builds with alpine>=3.9 result in failures such as:

```
In file included from lib/usual/socket.h:54,
                 from lib/usual/tls/tls_compat.h:10,
                 from lib/usual/tls/tls.c:18:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
 #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
  ^~~~~~~
In file included from lib/usual/tls/tls.h:25,
                 from lib/usual/tls/tls_compat.h:5,
                 from lib/usual/tls/tls.c:18:
lib/usual/base.h:336:17: error: conflicting types for '_const_free'
 #define free(x) _const_free(x)
                 ^~~~~~~~~~~
lib/usual/base.h:331:20: note: previous definition of '_const_free' was here
 static inline void _const_free(const void *p)
                    ^~~~~~~~~~~
make: *** [/src/lib/mk/antimake.mk:1230: .objs/pgbouncer/lib/usual/tls/tls.o] Error 1
The command '/bin/sh -c make' returned a non-zero code: 2
```